### PR TITLE
Server notifications about client disconnection

### DIFF
--- a/client/src/main/java/battleships/communication/server/ServerComm.java
+++ b/client/src/main/java/battleships/communication/server/ServerComm.java
@@ -11,6 +11,8 @@ import battleships.logger.BattleshipLog;
 import battleships.ships.Fleet;
 import javafx.concurrent.Task;
 
+import java.io.IOException;
+
 class ServerComm implements Member, Publisher {
 
   private final BattleshipLog log = BattleshipLog.provideLogger(ServerComm.class);
@@ -60,7 +62,7 @@ class ServerComm implements Member, Publisher {
     log.info("processing replay...");
   }
 
-  Messageable waitForMessage() {
+  Messageable waitForMessage() throws IOException, ClassNotFoundException {
     return clientHandler.receiveMessage();
   }
 

--- a/client/src/main/java/battleships/communication/server/ServerConnector.java
+++ b/client/src/main/java/battleships/communication/server/ServerConnector.java
@@ -3,6 +3,7 @@ package battleships.communication.server;
 import battleships.communication.ClientHandler;
 import battleships.communication.ClientHandlerBuilder;
 import battleships.communication.messages.WelcomeMessage;
+import battleships.logger.BattleshipLog;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -13,6 +14,7 @@ import java.net.Socket;
 public class ServerConnector {
 
   private final ServerComm serverComm;
+  private final BattleshipLog log = BattleshipLog.provideLogger(ServerConnector.class);
 
   ServerConnector(ServerComm serverComm) {
     this.serverComm = serverComm;
@@ -54,9 +56,13 @@ public class ServerConnector {
    */
   public boolean setUp() {
     boolean connectionEstablish = false;
-    if (serverComm.waitForMessage() instanceof WelcomeMessage) {
-      connectionEstablish = true;
-      serverComm.register();
+    try {
+      if (serverComm.waitForMessage() instanceof WelcomeMessage) {
+        connectionEstablish = true;
+        serverComm.register();
+      }
+    } catch (IOException | ClassNotFoundException ex) {
+      log.error(ex.getMessage());
     }
     return connectionEstablish;
   }

--- a/client/src/main/java/battleships/game/OpponentBoardViewController.java
+++ b/client/src/main/java/battleships/game/OpponentBoardViewController.java
@@ -4,13 +4,17 @@ import battleships.AlertWithProgressIndicator;
 import battleships.communication.DataBus;
 import battleships.communication.Member;
 import battleships.communication.Messageable;
+import battleships.communication.messages.FlowState;
+import battleships.communication.messages.Notification;
 import battleships.communication.messages.Salvo;
 import battleships.communication.messages.SalvoResult;
 import battleships.logger.BattleshipLog;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Text;
@@ -19,6 +23,7 @@ import javafx.stage.Modality;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 /**
@@ -123,6 +128,22 @@ public class OpponentBoardViewController implements Member, Initializable {
       log.info("SalvoResult received by controller");
       if (salvoResult.getGameResult() != GameResult.NONE) {
         gameEnd();
+      }
+    } else if (data instanceof Notification) {
+      processNotification((Notification) data);
+    }
+  }
+
+  private void processNotification(Notification message) {
+    if (message.getFlowState() == FlowState.CLIENT_DISCONNECT) {
+      Alert alert = new Alert(Alert.AlertType.WARNING,
+              resourceBundle.getString("CLIENT_DISCONNECT"),
+              ButtonType.OK);
+      alert.initOwner(dockedGridPane.getScene().getWindow());
+      alert.initModality(Modality.APPLICATION_MODAL);
+      final Optional<ButtonType> result = alert.showAndWait();
+      if (result.isPresent() && result.get() == ButtonType.OK) {
+        Platform.exit();
       }
     }
   }

--- a/client/src/main/resources/EN.properties
+++ b/client/src/main/resources/EN.properties
@@ -17,3 +17,4 @@ PLAYER=Player
 CONNECTING=Connecting
 RESPONSE_WAITING=Waiting for response
 SERVER_RESPONSE_WAITING=Waiting for response from server
+CLIENT_DISCONNECT=Unfortunately, second player disconnect.

--- a/client/src/main/resources/PL.properties
+++ b/client/src/main/resources/PL.properties
@@ -17,3 +17,4 @@ PLAYER=Gracz
 CONNECTING=Nawi\u0105zywanie po\u0142\u0105czenia
 RESPONSE_WAITING=Oczekuj\u0119 na odpowied\u017A
 SERVER_RESPONSE_WAITING=Oczekiwanie na odpowied\u017A z serwera
+CLIENT_DISCONNECT=Niestety, drugi gracz się roz\u0142\u0105czy\u0142.

--- a/client/src/test/java/battleships/communication/server/ServerCommTest.java
+++ b/client/src/test/java/battleships/communication/server/ServerCommTest.java
@@ -10,6 +10,8 @@ import battleships.ships.Fleet;
 import battleships.ships.Ship;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
 import java.util.Collections;
 import static battleships.utils.BattleshipUtils.*;
 import static org.mockito.Mockito.*;
@@ -74,8 +76,14 @@ public class ServerCommTest {
   }
 
   @Test
-  public void whenInvokingWaitForMessage_expectClientHandlerInvokeReceiveMessageOnce() {
+  public void whenInvokingWaitForMessage_expectClientHandlerInvokeReceiveMessageOnce() throws IOException, ClassNotFoundException {
     serverComm.waitForMessage();
     verify(clientHandler, times(1)).receiveMessage();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void whenClientHandlerThrowsRuntimeException_expectWaitForMessageToThrowException() throws IOException, ClassNotFoundException {
+    doThrow(new RuntimeException()).when(clientHandler).receiveMessage();
+    verify(serverComm.waitForMessage());
   }
 }

--- a/client/src/test/java/battleships/communication/server/ServerConnectorTest.java
+++ b/client/src/test/java/battleships/communication/server/ServerConnectorTest.java
@@ -6,6 +6,8 @@ import battleships.ships.Fleet;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -20,7 +22,7 @@ public class ServerConnectorTest {
     }
 
     @Test
-    public void whenTryingToConnect_andServerSendsWelcomeMessage_expectMethodEstablishToReturnTrue(){
+    public void whenTryingToConnect_andServerSendsWelcomeMessage_expectMethodEstablishToReturnTrue() throws IOException, ClassNotFoundException {
         //given
         Messageable welcomeMessage = mock(WelcomeMessage.class);
         when(serverComm.waitForMessage()).thenReturn(welcomeMessage);
@@ -38,7 +40,7 @@ public class ServerConnectorTest {
     }
 
     @Test
-    public void whenTryingToConnect_andServerSendsMessageOtherThenWelcomeMessage_expectMethodEstablishToReturnFalse(){
+    public void whenTryingToConnect_andServerSendsMessageOtherThenWelcomeMessage_expectMethodEstablishToReturnFalse() throws IOException, ClassNotFoundException {
         //given
         Messageable fleet = mock(Fleet.class);
         when(serverComm.waitForMessage()).thenReturn(fleet);

--- a/common/src/main/java/battleships/communication/ClientHandler.java
+++ b/common/src/main/java/battleships/communication/ClientHandler.java
@@ -3,6 +3,7 @@ package battleships.communication;
 import battleships.communication.jsonhandlers.JsonMarshaller;
 import battleships.communication.jsonhandlers.JsonUnmarshaller;
 
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -40,11 +41,11 @@ public class ClientHandler {
    *
    * @return optional Messageable received by MessageReceiver and converted by jsonUnmarshaller.
    */
-  public Messageable receiveMessage() {
+  public Messageable receiveMessage() throws IOException, ClassNotFoundException {
     String messageString = messageReceiver.receiveMessageString();
     Optional<Messageable> message = jsonUnmarshaller.toMessageable(messageString);
     if (!message.isPresent()) {
-      throw new RuntimeException("message not received");
+      throw new MessagableNotReceived("message not received");
     }
     return message.get();
   }

--- a/common/src/main/java/battleships/communication/MessagableNotReceived.java
+++ b/common/src/main/java/battleships/communication/MessagableNotReceived.java
@@ -1,0 +1,7 @@
+package battleships.communication;
+
+public class MessagableNotReceived extends RuntimeException {
+  public MessagableNotReceived(String message) {
+    super(message);
+  }
+}

--- a/common/src/main/java/battleships/communication/MessageReceiver.java
+++ b/common/src/main/java/battleships/communication/MessageReceiver.java
@@ -1,7 +1,6 @@
 package battleships.communication;
 
 import battleships.logger.BattleshipLog;
-import battleships.utils.BattleshipUtils;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -22,14 +21,10 @@ public class MessageReceiver {
    *
    * @return string received from ObjectInputStream
    */
-  public String receiveMessageString() {
-    String receivedString = BattleshipUtils.provideEmptyString();
-    try {
-      receivedString = (String) ois.readObject();
-      log.info("message received: " + receivedString);
-    } catch (IOException | ClassNotFoundException ex) {
-      log.error(ex.getMessage());
-    }
+  //I've decided to throw exception to be able to proper handle it in upper layers
+  public String receiveMessageString() throws IOException, ClassNotFoundException {
+    String receivedString = (String) ois.readObject();
+    log.info("message received: " + receivedString);
     return receivedString;
   }
 }

--- a/common/src/main/java/battleships/communication/Messageable.java
+++ b/common/src/main/java/battleships/communication/Messageable.java
@@ -1,9 +1,12 @@
 package battleships.communication;
 
+import battleships.communication.messages.FlowState;
+import battleships.communication.messages.Notification;
 import battleships.communication.messages.Salvo;
 import battleships.communication.messages.SalvoResult;
 import battleships.communication.messages.WelcomeMessage;
 import battleships.ships.Fleet;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -19,7 +22,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = WelcomeMessage.class, name = "WelcomeMessage"),
     @JsonSubTypes.Type(value = Fleet.class, name = "Fleet"),
     @JsonSubTypes.Type(value = Salvo.class, name = "Salvo"),
-    @JsonSubTypes.Type(value = SalvoResult.class, name = "SalvoResult")}
+    @JsonSubTypes.Type(value = SalvoResult.class, name = "SalvoResult"),
+    @JsonSubTypes.Type(value = Notification.class, name = "Notification"),
+    @JsonSubTypes.Type(value = FlowState.class, name = "FlowState")}
     )
 public interface Messageable {
 }

--- a/common/src/main/java/battleships/communication/messages/FlowState.java
+++ b/common/src/main/java/battleships/communication/messages/FlowState.java
@@ -1,0 +1,9 @@
+package battleships.communication.messages;
+
+/**
+ * Represents state of game flow, such as:
+ * one client disconnect, everything is fine, etc.
+ */
+public enum FlowState {
+    CLIENT_DISCONNECT, RUNNING
+}

--- a/common/src/main/java/battleships/communication/messages/Notification.java
+++ b/common/src/main/java/battleships/communication/messages/Notification.java
@@ -1,0 +1,32 @@
+package battleships.communication.messages;
+
+import battleships.communication.Messageable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents notification sent by server to client
+ * including information about game flow, such as:
+ * one client disconnect, everything is fine, etc.
+ */
+public class Notification implements Messageable {
+
+  private final FlowState flowState;
+
+  /**
+   * This is a constructor for Notification. It is used by Jackson library as a property based creator.
+   */
+  @JsonCreator
+  public Notification(
+      @JsonProperty("flowState") FlowState flowState) {
+    this.flowState = flowState;
+  }
+
+  /**
+   * It returns a including information about game flow.
+   */
+  public FlowState getFlowState() {
+    return flowState;
+  }
+
+}

--- a/common/src/test/java/battleships/communication/MessageSenderReceiverTest.java
+++ b/common/src/test/java/battleships/communication/MessageSenderReceiverTest.java
@@ -8,7 +8,7 @@ import static org.testng.Assert.*;
 
 public class MessageSenderReceiverTest {
   @Test
-  public void whenMessageSenderSendsMessageString_expectItCanBeReceivedByMessageReceiver() throws IOException {
+  public void whenMessageSenderSendsMessageString_expectItCanBeReceivedByMessageReceiver() throws IOException, ClassNotFoundException {
     String expectedValue = "test message";
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     MessageSender messageSender = new MessageSender(new ObjectOutputStream(baos));

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
 
         <!-- sonar -->
         <sonar.coverage.exclusions>**/LanguageLoadOption.*, **/SalvoCount.*, **/GameResult.*, **/Salvo.*,
-            **/SalvoResult.*, **/BattleshipLog.*, **/RootLayoutController.*, **/LoggingController.*</sonar.coverage.exclusions>
+            **/SalvoResult.*, **/BattleshipLog.*, **/RootLayoutController.*, **/LoggingController.*, **/Notification.*,
+            **/FlowState.*</sonar.coverage.exclusions>
         <sonar.test.exclusions>**/CreateSocketsIT.*, **/MessagesAreSentFromServerIT.*, **/ReceiveMessageIT.*</sonar.test.exclusions>
     </properties>
 
@@ -232,6 +233,8 @@
                             <exclude>**/BattleshipLog.*</exclude>
                             <exclude>**/RootLayoutController.*</exclude>
                             <exclude>**/LoggingController.*</exclude>
+                            <exclude>**/Notification.*</exclude>
+                            <exclude>**/FlowState.*</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/server/src/main/java/battleships/HandlerWrapper.java
+++ b/server/src/main/java/battleships/HandlerWrapper.java
@@ -2,12 +2,18 @@ package battleships;
 
 import battleships.communication.ClientHandler;
 import battleships.communication.Messageable;
+import battleships.logger.BattleshipLog;
+import com.sun.nio.sctp.IllegalReceiveException;
+
+import java.io.IOException;
 
 /**
  * This is a wrapper class for ClientHandler. It is used to send and receive messages.
  */
 public class HandlerWrapper implements Observers {
+
   private final ClientHandler clientHandler;
+  private BattleshipLog log = BattleshipLog.provideLogger(HandlerWrapper.class);
 
   public HandlerWrapper(ClientHandler clientHandler) {
     this.clientHandler = clientHandler;
@@ -20,6 +26,13 @@ public class HandlerWrapper implements Observers {
 
   @Override
   public Messageable receiveMessage() {
-    return clientHandler.receiveMessage();
+    try {
+      return clientHandler.receiveMessage();
+    } catch (ClassNotFoundException ex) {
+      log.error(ex.getMessage());
+    } catch (IOException ex) {
+      throw new IllegalReceiveException("Client disconnect");
+    }
+    return null;
   }
 }

--- a/server/src/main/java/battleships/ServerRunner.java
+++ b/server/src/main/java/battleships/ServerRunner.java
@@ -22,7 +22,8 @@ class ServerRunner {
     this.server = server;
   }
 
-  static ServerRunner createInstance(int gamesAtOnceLimit, int serverPortNumber) throws IOException {
+  static ServerRunner createInstance(int gamesAtOnceLimit, int serverPortNumber)
+          throws IOException {
     Server server = ServerBuilder
         .withPort(serverPortNumber)
         .openServerSocket()

--- a/server/src/main/java/battleships/gameplay/Game.java
+++ b/server/src/main/java/battleships/gameplay/Game.java
@@ -1,8 +1,11 @@
 package battleships.gameplay;
 
 import battleships.Observers;
+import battleships.communication.messages.FlowState;
+import battleships.communication.messages.Notification;
 import battleships.logger.BattleshipLog;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -21,11 +24,16 @@ public class Game {
    * Then process each game state until game ends by one of outcomes.
    */
   public void start() {
-    log.info("Game started");
-    GameState gameState = new SendingWelcomeMessage(clientHandlers);
-    do {
-      gameState = gameState.process();
-    } while (!gameState.isEndOfTheGame());
+    try {
+      log.info("Game started");
+      GameState gameState = new SendingWelcomeMessage(clientHandlers);
+      do {
+        gameState = gameState.process();
+      } while (!gameState.isEndOfTheGame());
+    } catch (IOException ex) {
+      clientHandlers.stream()
+              .forEach(client -> client.sendMessage(new Notification(FlowState.CLIENT_DISCONNECT)));
+    }
     log.info("Game ended");
   }
 }

--- a/server/src/main/java/battleships/gameplay/GameState.java
+++ b/server/src/main/java/battleships/gameplay/GameState.java
@@ -1,5 +1,7 @@
 package battleships.gameplay;
 
+import java.io.IOException;
+
 /**
  * This interface represents game state that can be processed and also indicates
  * the end of the game.
@@ -8,7 +10,7 @@ public interface GameState {
   /**
    * This method process current game state and return next game state.
    */
-  GameState process();
+  GameState process() throws IOException;
 
   /**
    * Method used to check if game ends.

--- a/server/src/main/java/battleships/gameplay/WaitingForFleets.java
+++ b/server/src/main/java/battleships/gameplay/WaitingForFleets.java
@@ -3,7 +3,9 @@ package battleships.gameplay;
 import battleships.Observers;
 import battleships.logger.BattleshipLog;
 import battleships.ships.Fleet;
+import com.sun.nio.sctp.IllegalReceiveException;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,12 +23,16 @@ class WaitingForFleets implements GameState {
    * @return next game state that is WaitingForSalvos.
    */
   @Override
-  public GameState process() {
-    log.info("Waiting for fleet");
-    return new WaitingForSalvos(observers, observers
-        .stream()
-        .map(handlerWrapper -> (Fleet) handlerWrapper.receiveMessage())
-        .collect(Collectors.toList()));
+  public GameState process() throws IOException {
+    try {
+      log.info("Waiting for fleet");
+      return new WaitingForSalvos(observers, observers
+              .stream()
+              .map(handlerWrapper -> (Fleet) handlerWrapper.receiveMessage())
+              .collect(Collectors.toList()));
+    } catch (IllegalReceiveException ex) {
+      throw new IOException(ex.getMessage());
+    }
   }
 
   /**

--- a/server/src/main/java/battleships/gameplay/WaitingForSalvos.java
+++ b/server/src/main/java/battleships/gameplay/WaitingForSalvos.java
@@ -4,7 +4,9 @@ import battleships.Observers;
 import battleships.communication.messages.Salvo;
 import battleships.logger.BattleshipLog;
 import battleships.ships.Fleet;
+import com.sun.nio.sctp.IllegalReceiveException;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,11 +27,15 @@ class WaitingForSalvos implements GameState {
    * @return next game state that is SalvoProcessing.
    */
   @Override
-  public GameState process() {
-    log.info("Waiting for salvos");
-    List<Salvo> salvos = observers.stream().map(p -> (Salvo) p.receiveMessage())
-        .collect(Collectors.toList());
-    return new SalvosProcessing(observers, playersFleets, salvos);
+  public GameState process() throws IOException {
+    try {
+      log.info("Waiting for salvos");
+      List<Salvo> salvos = observers.stream().map(p -> (Salvo) p.receiveMessage())
+              .collect(Collectors.toList());
+      return new SalvosProcessing(observers, playersFleets, salvos);
+    } catch (IllegalReceiveException ex) {
+      throw new IOException(ex.getMessage());
+    }
   }
 
   /**

--- a/server/src/test/java/battleships/HandlerWrapperTest.java
+++ b/server/src/test/java/battleships/HandlerWrapperTest.java
@@ -2,10 +2,14 @@ package battleships;
 
 import battleships.communication.ClientHandler;
 import battleships.communication.messages.WelcomeMessage;
+import com.sun.nio.sctp.IllegalReceiveException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,7 +23,7 @@ public class HandlerWrapperTest {
   }
 
   @Test
-  public void whenHandlerWrapperReceivesMessage_expectClientHandlerMockReceiveMessageMethodIsRunOnce() {
+  public void whenHandlerWrapperReceivesMessage_expectClientHandlerMockReceiveMessageMethodIsRunOnce() throws IOException, ClassNotFoundException {
     //given
     HandlerWrapper handlerWrapper = new HandlerWrapper(clientHandlerMock);
     //when
@@ -36,5 +40,13 @@ public class HandlerWrapperTest {
     handlerWrapper.sendMessage(new WelcomeMessage("hello"));
     //then
     verify(clientHandlerMock, times(1)).sendMessage(any(WelcomeMessage.class));
+  }
+
+  @Test(expectedExceptions = IllegalReceiveException.class)
+  public void whenClientHandlerThrowsIOException_expectReceiveMessageMethodToThrowIllegalReceiveException()
+      throws IOException, ClassNotFoundException {
+    doThrow(new IOException()).when(clientHandlerMock).receiveMessage();
+    HandlerWrapper handlerWrapper = new HandlerWrapper(clientHandlerMock);
+    handlerWrapper.receiveMessage();
   }
 }

--- a/server/src/test/java/battleships/ServerAppTest.java
+++ b/server/src/test/java/battleships/ServerAppTest.java
@@ -34,7 +34,8 @@ public class ServerAppTest {
   @Test
   public void whenServerAppRunWithWrongPortNumber_expectedLogWithInformationAboutInvalidPortNumber() throws UnsupportedEncodingException {
     System.setProperty("port", "xxx");
-    ServerApp.main(null);
+    String[] args = new String[0];
+    ServerApp.main(args);
 
     verify(mockAppender).doAppend(captorLoggingEvent.capture());
     LoggingEvent loggingEvent = captorLoggingEvent.getValue();

--- a/server/src/test/java/battleships/gameplay/CalculatingGameResultTest.java
+++ b/server/src/test/java/battleships/gameplay/CalculatingGameResultTest.java
@@ -4,6 +4,7 @@ import battleships.game.GameResult;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -12,7 +13,7 @@ import static org.mockito.Mockito.mock;
 public class CalculatingGameResultTest {
 
   @Test(dataProvider = "calculatingResultProvider")
-  public void whenGivenDataIsProcessedByShipSinkingAndResultCalculating_expectResultToMatchExpectedResult(Triplet triplet, int playerIndex, GameResult expectedResult) {
+  public void whenGivenDataIsProcessedByShipSinkingAndResultCalculating_expectResultToMatchExpectedResult(Triplet triplet, int playerIndex, GameResult expectedResult) throws IOException {
     //given
     SinkingShips sinkingShips = new SinkingShips(triplet.observers, triplet.fleets, triplet.salvoResults);
     //when

--- a/server/src/test/java/battleships/gameplay/WaitingForFleetsTest.java
+++ b/server/src/test/java/battleships/gameplay/WaitingForFleetsTest.java
@@ -5,6 +5,8 @@ import battleships.HandlerWrapper;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -25,7 +27,7 @@ public class WaitingForFleetsTest {
   }
 
   @Test
-  public void whenProcessingWaitingForFleets_expectFirstObserverReceivesMessageOnce() {
+  public void whenProcessingWaitingForFleets_expectFirstObserverReceivesMessageOnce() throws IOException {
     //given
     WaitingForFleets waitingForFleets = new WaitingForFleets(handlerWrappersMocks);
     //when
@@ -35,7 +37,7 @@ public class WaitingForFleetsTest {
   }
 
   @Test
-  public void whenProcessingWaitingForFleets_expectSecondObserverReceivesMessageOnce() {
+  public void whenProcessingWaitingForFleets_expectSecondObserverReceivesMessageOnce() throws IOException {
     //given
     WaitingForFleets waitingForFleets = new WaitingForFleets(handlerWrappersMocks);
     //when
@@ -52,5 +54,16 @@ public class WaitingForFleetsTest {
     boolean isEndOfTheGame = waitingForFleets.isEndOfTheGame();
     //then
     assertThat(isEndOfTheGame).isFalse();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class,  expectedExceptionsMessageRegExp = "message not received")
+  public void whenReceiveMessageMethodThrowsRuntimeException_expectProcessMethodToThrowRuntimeException() throws IOException {
+    Observers playerSocketHandler = mock(Observers.class);
+    List<Observers> observers = new ArrayList<>();
+    observers.add(playerSocketHandler);
+    observers.add(playerSocketHandler);
+    doThrow(new RuntimeException("message not received")).when(playerSocketHandler).receiveMessage();
+    WaitingForFleets waitingForFleets = new WaitingForFleets(observers);
+    waitingForFleets.process();
   }
 }

--- a/server/src/test/java/battleships/gameplay/WaitingForSalvosTest.java
+++ b/server/src/test/java/battleships/gameplay/WaitingForSalvosTest.java
@@ -6,6 +6,7 @@ import battleships.ships.Fleet;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +31,7 @@ public class WaitingForSalvosTest {
   }
 
   @Test
-  public void whenProcessingWaitingForSalvos_expectFirstObserverReceivesMessageOnce() {
+  public void whenProcessingWaitingForSalvos_expectFirstObserverReceivesMessageOnce() throws IOException {
     //given
     WaitingForSalvos waitingForSalvosTest = new WaitingForSalvos(observersList, fleets);
     //when
@@ -40,7 +41,7 @@ public class WaitingForSalvosTest {
   }
 
   @Test
-  public void whenProcessingWaitingForSalvos_expectSecondObserverReceivesMessageOnce() {
+  public void whenProcessingWaitingForSalvos_expectSecondObserverReceivesMessageOnce() throws IOException {
     //given
     WaitingForSalvos waitingForSalvosTest = new WaitingForSalvos(observersList, fleets);
     //when

--- a/server/src/test/java/battleships/integrationtests/MessagesAreSentFromServerIT.java
+++ b/server/src/test/java/battleships/integrationtests/MessagesAreSentFromServerIT.java
@@ -106,7 +106,11 @@ public class MessagesAreSentFromServerIT {
           .addMessageSender()
           .addMessageReceiver()
           .build();
-      clientHandler.receiveMessage();
+      try {
+        clientHandler.receiveMessage();
+      } catch (IOException | ClassNotFoundException ex) {
+        ex.printStackTrace();
+      }
     }).start();
   }
 


### PR DESCRIPTION
### Description

Server sends notification about that second player close game before end.

### List general changes for this pull request:

* I've decided to throw exception from method receiveMessageString() of MessageReceiver class instead of logging it, to be able to handle this is upper layers. That exception indicates that client binded with that socket has close connection.
* Server sends notification to players in one game, that another players disconnected.
* Client show alert about second player disconnection, if it received notification from server.

### List of modules this pull request affects:
* common, server, client